### PR TITLE
Prefer safe navigation operator in anecdote.rb

### DIFF
--- a/lib/anecdote.rb
+++ b/lib/anecdote.rb
@@ -65,7 +65,7 @@ module Anecdote
       handler: lambda do |settings|
         klasses = ['anecdote-gallery-dn2bak']
         klasses += module_classes(settings)
-        graphics = settings[:_yield_].html_safe
+        graphics = settings[:_yield_]&.html_safe
 
         # handle scaling
         flexes = []


### PR DESCRIPTION
This leads to errors we see on Sentry.io fairly regularly.